### PR TITLE
Remove BlackBerry from the default platforms for new projects

### DIFF
--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -21,7 +21,7 @@ var TITANIUM = path.join(__dirname, '..', 'node_modules', '.bin', 'titanium'),
 		}, GLOBAL_FLAGS),
 		create: _.extend({
 			workspaceDir: '.',
-			platforms: 'android,blackberry,ios,ipad,iphone,mobileweb'
+			platforms: 'android,ios,ipad,iphone,mobileweb'
 		}, GLOBAL_FLAGS)
 	};
 


### PR DESCRIPTION
Because I don't have BlackBerry configured on my system, I get an error when attempting to start triple:

```
(~/Documents/Titanium_Studio_Workspace) ≫ triple
[creating app]
[ERROR] Invalid platform: blackberry

[ERROR] Invalid "--platforms" value "android,blackberry,ios,ipad,iphone,mobileweb"

[ERROR] Invalid platform: blackberry

[ERROR] Invalid "--platforms" value "android,blackberry,ios,ipad,iphone,mobileweb"
```

I tried a couple of ways to pass in the target platform. There's probably a way. But for now, since Triple doesn't support BlackBerry, the easiest way was to remove it from the defaults for new projects.
