### PR TITLE
#28 Native modules now supported via CLI flag

### DIFF
--- a/bin/triple
+++ b/bin/triple
@@ -8,6 +8,9 @@ var chalk = require('chalk'),
 program.description('REPL for Titanium')
 	.version(require('../package.json').version)
 	.usage('[options]')
+	.option('-m, --module <ids>', 'Add native module(s) to REPL VM', function list(val) {
+		return val.split(',');
+	})
 	.option('-v, --verbose', 'Enable verbose output')
 
 program.parse(process.argv);

--- a/lib/triple.js
+++ b/lib/triple.js
@@ -5,6 +5,7 @@ var _ = require('lodash'),
 	constants = require('./constants'),
 	fs = require('fs-extra'),
 	path = require('path'),
+	tiapp = require('tiapp.xml'),
 	readline = require('readline'),
 	server = require('./server'),
 	spinner = require('char-spinner'),
@@ -117,6 +118,23 @@ module.exports = function(opts, callback) {
 				copy(path.join(app, file), path.join(resources, file));
 			});
 			copy(path.join(__dirname, 'constants.js'), path.join(resources, 'constants.js'));
+
+			cb();
+		},
+
+		// update tiapp.xml
+		function(cb) {
+			if(opts.module) {
+					tiappXML = path.join(DEFAULTS.PROJECT, 'tiapp.xml'),
+					tiappLoaded = tiapp.load(path.resolve(tiappXML));
+
+				console.log('[Injecting module: %s]', opts.module);
+
+				for(var moduleID in opts.module) {
+					tiappLoaded.setModule(moduleID);
+				}
+				tiappLoaded.write();
+			}
 
 			cb();
 		},

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "commander": "^2.2.0",
     "fs-extra": "^0.10.0",
     "lodash": "^2.4.1",
-    "titanium": "^3.2.3",
-    "request": "^2.39.0"
+    "request": "^2.39.0",
+    "tiapp.xml": "^0.2.0",
+    "titanium": "^3.2.3"
   }
 }


### PR DESCRIPTION
Used a list in a -m / --module flag. for instance:
triple -m com.appersonlabs.global,com.test.foo
