### PR TITLE
Specify a folder (and run app.js by default)

### DIFF
--- a/bin/triple
+++ b/bin/triple
@@ -29,6 +29,10 @@ program.on('--help', function(){
 	console.log('    $ triple http://bit.ly/1zc7Nvo');
 	console.log('    $ triple /path/to/file.js 2000');
 	console.log('');
+	console.log('    ' + under('load by folder, triple automtically runs app.js in the folder, with optional delay'));	
+	console.log('    $ triple /path/to');
+	console.log('    $ triple /path/to 2000');
+	console.log('');
 	console.log('    ' + under('add native module(s) to REPL by id'));
 	console.log('    $ triple --module ti.paint');
 	console.log('    $ triple --module some.module,another.module');

--- a/lib/triple.js
+++ b/lib/triple.js
@@ -347,6 +347,12 @@ function load(tokens, rl) {
 	// probably a file
 	} else {
 		if (fs.existsSync(location)) {
+
+			// if it's a folder, default to app.js
+			if (fs.lstatSync(location).isDirectory()) {
+				location = location + '/app.js';
+			}
+			
 			return sendLoadCommand(rl, location, fs.readFileSync(location).toString(), delay);
 		}
 	}


### PR DESCRIPTION
$ triple example1

$ triple example2

would run app.js by default in the folder.
