### PR TITLE
disable analytics

### DIFF
--- a/lib/triple.js
+++ b/lib/triple.js
@@ -144,16 +144,22 @@ module.exports = function(opts, callback) {
 
 			// copy in shared constants file
 			copy(path.join(__dirname, 'constants.js'), path.join(resources, 'constants.js'));
-
+			
+			// load tiapp.xml
+			var tiapp = tiappXml.load(path.resolve(TRIPLE_APP, 'tiapp.xml'));
+			
+			// disable analytics
+			tiapp.analytics = false;
+			
 			// load native modules into tiapp.xml
 			if(opts.module) {
-				var tiapp = tiappXml.load(path.resolve(TRIPLE_APP, 'tiapp.xml'));
 				opts.module.forEach(function(id) {
 					logger.log('[Injecting module: %s]', id);
 					tiapp.setModule(id);
 				});
-				tiapp.write();
 			}
+			
+			tiapp.write();
 
 			cb();
 		},


### PR DESCRIPTION
I've just seen these bunch of __tmp_ projects in the [My Apps](https://my.appcelerator.com/apps) section of my Appcelerator account. I thought it would make sense to disable analytics on triple apps, doesn't it?
